### PR TITLE
Fix cmd task without options object

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -12,7 +12,7 @@ module.exports.exec = exec;
 function exec(pfx, args, opts) {
     pfx = chalk.blue("[" + pfx + "] ");
     opts = Object.assign({
-        env: Object.assign({}, process.env, opts.extraEnv || {}, {
+        env: Object.assign({}, process.env, opts && opts.extraEnv || {}, {
             PATH: path.resolve("node_modules/.bin") + ":" + process.env.PATH,
         }),
     }, opts);


### PR DESCRIPTION
This fix is required to restore the automatic git submodule checkout.