### PR TITLE
Improve mobile layout

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -111,11 +111,12 @@ header {
   &>div {
     padding: $default-padding;
     max-width: $max-width;
-    background-image: url("../img/logo_small.png");
-    background-position: 120px 0px;
-    background-repeat: no-repeat;
     margin: auto;
     display: flex;
+  }
+  .logo {
+    vertical-align: middle;
+    margin: -1rem 0.5rem;
   }
   h1 {
     margin: 0px;

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -313,7 +313,7 @@ pre {
   flex-shrink: 0.1;
 }
 
-.flex, .flex-reverse {
+.examplel, .exampler {
   display: flex;
   flex-direction: row;
   div {
@@ -324,14 +324,26 @@ pre {
     width: 300px;
     height: 300px;
   }
+  >h5 {
+    display: none;
+  }
 }
 
-.flex-reverse {
+.exampler {
   flex-direction: row-reverse;
 }
 
 @media #{$small} {
-  .flex, .flex-reverse { flex-direction: column;}
+  .examplel, .exampler {
+    flex-direction: column;
+    >h5 {
+      margin-top: 2em;
+      display: block;
+    }
+    >div>h5 {
+      display: none;
+    }
+  }
 }
 
 

--- a/src/layouts/main.html
+++ b/src/layouts/main.html
@@ -19,7 +19,7 @@
     <!-- Header -->
     <header class="top-bar">
       <div>
-        <h1><a href="/"><span style="font-weight:400">Cindy</span><span style="font-weight:700">JS</span></a></h1>
+        <h1><a href="/"><span style="font-weight:400">Cindy</span><span style="font-weight:700">JS</span><img alt="CindyJS logo" class="logo" src="/assets/img/logo_small.png"></a></h1>
         <nav>
           <ul id="topBarLinks">
             <li><a href="/gallery/">Gallery</a></li>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -11,7 +11,8 @@ Together, these components make it very easy to visualize various
 concepts, from geometry in particular and mathematics in general,
 but also from various other fields.
 
-<div class="flex">
+<div class="examplel">
+  <h5>Use CindyJS for your own interactive physics simulations</h5>
   <div id="Bouncer" class="example"></div>
   <div>
     <h5>Use CindyJS for your own interactive physics simulations</h5>
@@ -25,7 +26,8 @@ but also from various other fields.
   </div>
 </div>
 
-<div class="flex-reverse">
+<div class="exampler">
+  <h5>Add brain power to your applications with <i>CindyScript</i></h5>
   <div id="Tree" class="example"></div>
   <div>
     <h5>Add brain power to your applications with <i>CindyScript</i></h5>
@@ -39,7 +41,8 @@ but also from various other fields.
 </div>
 
 
-<div class="flex">
+<div class="examplel">
+  <h5>Use the GPU without learning WebGL</h5>
   <div id="ComplexPlot" class="example"></div>
   <div>
     <h5>Use the GPU without learning WebGL</h5>


### PR DESCRIPTION
This adjusts the layout for mobile devices in particular. The top bar icon now no longer overlaps with the top bar buttons (an issue pointed out in https://github.com/CindyJS/website/pull/4#issuecomment-239159569). And the body of the start page has headline then widget then text for the three examples, which I find easier to read.