### PR TITLE
Link to ICMS presentations and abstracts

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -342,7 +342,7 @@ gulp.task('server', ['rebuild'], function() {
         notify: false,
         ghostMode: false,
         rewriteRules: [{
-            match: /(['"])(\/dist\/)/g,
+            match: /(['"])(\/(dist|soundfont|docs)\/)/g,
             replace: "$1http://cindyjs.org$2"
         }],
     });

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -39,6 +39,7 @@ $index-example-width: 45vw;
 // Media selection
 
 $small: "only screen and (max-width: #{$small-size})";
+$not-small: "not screen and (max-width: #{$small-size})";
 
 //////////////////////////////////////////////////////////////////////
 // Fonts
@@ -297,6 +298,29 @@ pre {
   code {
     background-color: inherit;
     box-shadow: none;
+  }
+}
+
+//////////////////////////////////////////////////////////////////////
+// List formatting
+
+@media #{$not-small} {
+  ul.inlinelist {
+    display: block;
+    margin: 0em;
+    padding: 0em;
+
+    &>li {
+      display: inline;
+      &::before {
+        content: "● ";
+        margin: 0em 0.5em;
+      }
+      &:first-child::before {
+        content: "";
+        margin: 0em;
+      }
+    }
   }
 }
 

--- a/src/pages/project/index.md
+++ b/src/pages/project/index.md
@@ -5,3 +5,12 @@ title: The CindyJS Project
 ## Team
 
 There will be a short description of the CindyJS team here in the near future.
+
+## Presentations and Publications
+
+There were
+[presentations on CindyJS at the ICMS 2016 conference](/pub/2016-icms/).
+These three presentations are available here as well:
+[one giving an overview](/pub/2016-icms/overview/),
+[one describing the plugin system](/pub/2016-icms/plugins/) and
+[one highlighting the CindyGL plugin](/pub/2016-icms/cindygl/).

--- a/src/pages/project/index.md
+++ b/src/pages/project/index.md
@@ -10,7 +10,8 @@ There will be a short description of the CindyJS team here in the near future.
 
 There were
 [presentations on CindyJS at the ICMS 2016 conference](/pub/2016-icms/).
+
 These three presentations are available here as well:
-[one giving an overview](/pub/2016-icms/overview/),
-[one describing the plugin system](/pub/2016-icms/plugins/) and
-[one highlighting the CindyGL plugin](/pub/2016-icms/cindygl/).
+* [one giving an overview](/pub/2016-icms/overview/),
+* [one describing the plugin system](/pub/2016-icms/plugins/) and
+* [one highlighting the CindyGL plugin](/pub/2016-icms/cindygl/).

--- a/src/pages/pub/2016-icms/index.md
+++ b/src/pages/pub/2016-icms/index.md
@@ -1,0 +1,60 @@
+# ICMS 2016
+
+The [5th International Congress on Mathematical Software (ICMS)][ICMS16]
+was held in July 2016 at the Zuse Institute Berlin (ZIB).
+At that occasion members of the *CindyJS* team held three talks,
+illustrating different aspects of the *CindyJS* framework.
+The presentations and extended abstracts from this occasion are available here.
+
+[ICMS16]: http://icms2016.zib.de/
+
+## Overview
+
+[**Presentation (HTML)**](overview/) ∙
+[Extended Abstract (PDF)](/docs/2016-icms/ICMS_Extended_Abstract.pdf) ∙
+[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_39)
+
+Martin von Gagern, Ulrich Kortenkamp, Jürgen Richter-Gebert and Michael Strobel
+
+> The *CindyJS* Project brings interactive mathematical visualization
+> to a broad variety of devices. Using projective geometry, homotopy
+> methods and well tuned algorithms the *CindyJS* project is one of
+> the first real time capable software projects in this eld that at
+> the same time approaches high-level mathematical descriptions and
+> performance.
+
+## Plugins
+
+[**Presentation (HTML)**](plugins/) ∙
+[Extended Abstract (PDF)](/docs/2016-icms/ICMS_Plugins_Extended_Abstract.pdf) ∙
+[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_40)
+
+Martin von Gagern and Jürgen Richter-Gebert
+
+> *CindyJS* can be extended using plugins, two of which are presented here.
+> 
+> * *Cindy3D* enables displaying 3D content via WebGL.
+> * The *KaTeX* plugin typesets formulas within *CindyJS*.
+> 
+> We also discuss the general structure of plugins in CindyJS.
+
+## CindyGL
+
+[**Presentation (HTML)**](cindygl/) ∙
+[Extended Abstract (PDF)](/docs/2016-icms/ICMS_CindyGL_Extended_Abstract.pdf) ∙
+[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_44)
+
+Aaron Montag and Jürgen Richter-Gebert
+
+> The plugin *CindyGL* extends the *CindyJS* framework and leverages
+> WebGL for parallelized computations.  *CindyGL* provides access to
+> the GPU fragment shader for *CindyJS*.  Among other tasks, the
+> plugin *CindyGL* is used for real-time colorplots.  We introduce the
+> main principles, concepts and application of *CindyGL* and describe
+> the encountered technical challenges. Special focus is put on a
+> novel visualization scheme that uses feedback loops, which were
+> among the motivating forces of developing *CindyGL*. They can be
+> used for a wide range of applications. Some of them are numerical
+> simulations, cellular automatons and fractal generation, which are
+> described here.
+

--- a/src/pages/pub/2016-icms/index.md
+++ b/src/pages/pub/2016-icms/index.md
@@ -10,9 +10,11 @@ The presentations and extended abstracts from this occasion are available here.
 
 ## Overview
 
-[**Presentation (HTML)**](overview/) ∙
-[Extended Abstract (PDF)](/docs/2016-icms/ICMS_Extended_Abstract.pdf) ∙
-[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_39)
+<ul class="inlinelist">
+<li>[**Presentation (HTML)**](overview/)</li>
+<li>[Extended Abstract (PDF)](/docs/2016-icms/ICMS_Extended_Abstract.pdf)</li>
+<li>[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_39)</li>
+</ul>
 
 Martin von Gagern, Ulrich Kortenkamp, Jürgen Richter-Gebert and Michael Strobel
 
@@ -25,9 +27,11 @@ Martin von Gagern, Ulrich Kortenkamp, Jürgen Richter-Gebert and Michael Strobel
 
 ## Plugins
 
-[**Presentation (HTML)**](plugins/) ∙
-[Extended Abstract (PDF)](/docs/2016-icms/ICMS_Plugins_Extended_Abstract.pdf) ∙
-[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_40)
+<ul class="inlinelist">
+<li>[**Presentation (HTML)**](plugins/)</li>
+<li>[Extended Abstract (PDF)](/docs/2016-icms/ICMS_Plugins_Extended_Abstract.pdf)</li>
+<li>[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_40)</li>
+</ul>
 
 Martin von Gagern and Jürgen Richter-Gebert
 
@@ -40,9 +44,11 @@ Martin von Gagern and Jürgen Richter-Gebert
 
 ## CindyGL
 
-[**Presentation (HTML)**](cindygl/) ∙
-[Extended Abstract (PDF)](/docs/2016-icms/ICMS_CindyGL_Extended_Abstract.pdf) ∙
-[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_44)
+<ul class="inlinelist">
+<li>[**Presentation (HTML)**](cindygl/)</li>
+<li>[Extended Abstract (PDF)](/docs/2016-icms/ICMS_CindyGL_Extended_Abstract.pdf)</li>
+<li>[Springer Link](http://link.springer.com/chapter/10.1007/978-3-319-42432-3_44)</li>
+</ul>
 
 Aaron Montag and Jürgen Richter-Gebert
 

--- a/src/pages/pub/index.md
+++ b/src/pages/pub/index.md
@@ -1,0 +1,6 @@
+# Publications and Presentations
+
+## ICMS 2016
+
+There were [presentations on CindyJS at the ICMS 2016 conference](2016-icms/).
+The presentations and extended abstracts are available from this website.


### PR DESCRIPTION
While the ICMS presentations have been on the website for some time now, they were not accessible from other parts of the directory structure. This commit here adds an index document containing links to presentations, extended abstracts (uploaded separately for legal reasons) and Springer Link (which can be used among other things to export a citation in a format suitable for BibTeX or a number of other citation management tools). The *Project* page refers to these presentations and thus connects the content to the main navigation elements, making it findable through search engine crawlers and manual navigation.

It might make sense to illustrate the presentations using suitable screenshots, or perhaps even animated screenshots, but I'd leave that for a later pull request. We should also improve the styling of block quotes at some point, but that, too, can be done at some later time.