### PR TITLE
Fix GitHub links

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -157,7 +157,6 @@ gulp.task("pages", ["cjsdeps", "copyexampleimages", "copygallerydata"], function
                 }),
                 galleryindex(Galleries, "Gallery"),
                 addData(gallerynavigation("gallery")),
-                github("CindyJS/website"),
                 licenses.apache2()
             ),
             pipeline(

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -56,7 +56,9 @@ var Galleries = [{
     description: "These examples demonstrate the CindyGL-Plugin",
     imgpath: "", //local folder
 }, {
-    src: "CindyJS/examples/**/*.html",
+    cwd: "CindyJS",
+    base: "CindyJS",
+    src: "examples/**/*.html",
     dest: "examples",
     title: "Examples shipped with the source tree",
     description: "This shows the examples <a href='https://github.com/CindyJS/CindyJS'>from the repository</a>, demonstrating individual functions and operations. Most of them demonstrate a single technical feature and are not intended to be examples of what well-designed CindyJS widgets can look like.",
@@ -141,7 +143,8 @@ gulp.task("pages", ["cjsdeps", "copyexampleimages", "copygallerydata"], function
                 Galleries.map(
                     gallery => pipeline(
                         gulp.src([gallery.src], {
-                            base: gallery.base || gallery.src.split('/')[0]
+                            base: gallery.base || gallery.src.split('/')[0],
+                            cwd: gallery.cwd || ".",
                         }),
                         examples(),
                         addData(gallerynavigation(gallery.dest)),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,6 +61,7 @@ var Galleries = [{
     title: "Examples shipped with the source tree",
     description: "This shows the examples <a href='https://github.com/CindyJS/CindyJS'>from the repository</a>, demonstrating individual functions and operations. Most of them demonstrate a single technical feature and are not intended to be examples of what well-designed CindyJS widgets can look like.",
     imgpath: "/assets/img/thumbnail/",
+    github: "CindyJS/CindyJS",
 }];
 
 
@@ -139,21 +140,19 @@ gulp.task("pages", ["cjsdeps", "copyexampleimages", "copygallerydata"], function
             merge(
                 Galleries.map(
                     gallery => pipeline(
-                        gulp.src([gallery.src.split('/').slice(1).join('/')], {
-                            cwd: gallery.src.split('/')[0],
-                            base: gallery.src.split('/')[0]
+                        gulp.src([gallery.src], {
+                            base: gallery.base || gallery.src.split('/')[0]
                         }),
                         examples(),
                         addData(gallerynavigation(gallery.dest)),
-                        github(gallery.dest == 'examples' ? "CindyJS/CindyJS" : "CindyJS/website"),
+                        github(gallery.github || "CindyJS/website"),
                         index(gallery.dest, "src/layouts/gallery.html", xtend(gallery, gallerynavigation(gallery.dest))),
                         licenses.apache2()
                     )
                 )
             ),
             pipeline(
-                gulp.src(["gallery"], {
-                    cwd: "src",
+                gulp.src(["src/gallery"], {
                     base: "src"
                 }),
                 galleryindex(Galleries, "Gallery"),
@@ -198,8 +197,7 @@ gulp.task("copyexampleimages", [], function() {
 });
 
 gulp.task("copygallerydata", [], function() {
-    return gulp.src(['gallery/**/*', '!gallery/**/*.html'], {
-        cwd: "src",
+    return gulp.src(['src/gallery/**/*', '!src/gallery/**/*.html'], {
         base: "src"
     }).pipe(gulp.dest("dist")); //copies everything that is not a html
 });


### PR DESCRIPTION
A number of pages currently have broken links to github in the bottom right corner. These changes should fix them.

As a general rule I'd say we should try to avoid the `cwd` argument to `gulp.src`, except when referencing files inside the `CindyJS` submodule. And we should only add GitHub links if there actually are GitHub files associated with the pages in question.