### PR TITLE
Format reference manual more like its stand-alone version

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -225,9 +225,8 @@ main {
 }
 
 #between-bars nav {
-  //position: absolute;
-  //left: 0px;
-  float: right;
+  padding: $default-padding;
+  max-width: $max-width;
   h2 {
     font-family: Raleway, $sans;
     font-style: italic;
@@ -235,7 +234,7 @@ main {
     font-size: 1.23em;
     margin-top: 0em;
   }
-  margin: 4em 2em 2em 1em;
+  margin: 4em auto 2em;
   border: em-calc(1) solid $bar-color-1;
   border-radius: 1em;
   padding: $default-padding;
@@ -299,6 +298,69 @@ pre {
     background-color: inherit;
     box-shadow: none;
   }
+}
+
+//////////////////////////////////////////////////////////////////////
+// Reference manual (similar to CindyJS/ref/ref.css)
+
+.codeblock {
+  pre {
+    background-color: inherit;
+    box-shadow: none;
+    border-style: none;
+    border-radius: 0em;
+  }
+
+  border: 1px solid #66cc66;
+  padding: 3px;
+  margin: 0ex 3em;
+  background: #ddddff;
+  pre { margin: 0px; padding: 2px; }
+  pre.code { color: #000066; margin-top: 1em; padding: 0px; }
+  pre.code.fst { margin-top: 0px; }
+  pre.result { color: #006600; background: #ddffdd; }
+  pre.regexp { color: #99ccaa; background: #eeffdd; }
+  pre.output { color: #993333; background: #dddddd; }
+  pre.draw2d { color: #aa9999; background: #ddeedd; }
+  pre.pragma { color: #996600; background: #ffffcc; }
+}
+
+table {
+  border-collapse:collapse;
+  td, th {
+    padding: 0.5ex 1em;
+    border: 1px solid black;
+    background: #ffffff;
+  }
+  code {
+    background-color: inherit;
+    box-shadow: none;
+  }
+}
+
+a.hlink {
+  margin-left: 0.5em;
+  opacity: 0.1;
+  color: #003;
+  &:hover {
+    opacity: 0.8;
+  }
+  &::after {
+    content: "¶";
+  }
+}
+
+kbd {
+  display: inline-block;
+  padding: 0.2em 0.3em;
+  margin: 0em 0.1em;
+  color: #555;
+  vertical-align: middle;
+  background-color: #eee;
+  border: solid 1px #bbb;
+  border-bottom-color: #aaa;
+  border-radius: 0.3em;
+  box-shadow: inset 0 -1px 0 #aaa;
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This imports and adjusts a number of settings from [`CindyJS/ref/ref.css`](https://github.com/CindyJS/CindyJS/blob/b16f7ae3174a0d9cbcef1fe0b1b1dde8c4e830aa/ref/ref.css), so that the manual developers can create locally and the one on the web page look more alike.  If the web version should change in the future, it might make sense to port these changes to CindyJS for the sake of consistency.

Some of the formatting, like e.g. the default format for tables, will affect other pages as well.

The modifications to the table of content were a drive-by fix, motivated by the obervation that code block background and floated toc don't work well together.  And many toc rows will be too long for a float anyway, so let's just consistently prepend the toc to the actual page content.