### PR TITLE
Redirects

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var cmd = require("./lib/cmd");
 var examples = require("./lib/examples");
 var index = require("./lib/index");
 var licenses = require("./lib/licenses");
+var redirect = require("./lib/redirect");
 var ref = require("./lib/ref");
 var relativize = require("./lib/relativize");
 var toc = require("./lib/toc");
@@ -211,10 +212,16 @@ gulp.task("copygallerydata", [], function() {
     }).pipe(gulp.dest("dist")); //copies everything that is not a html
 });
 
-
-
 gulp.task("asis", [], function() {
     return gulp.src("src/asis/**/*").pipe(gulp.dest("dist"));
+});
+
+gulp.task("redirect", [], function() {
+    return pipeline(
+        gulp.src("src/redirect/*.json"),
+        redirect(),
+        $.concat(".htaccess"),
+        gulp.dest("dist"));
 });
 
 gulp.task("validate", ["pages", "asis"], function() {
@@ -327,7 +334,7 @@ gulp.task('images', function() {
 });
 
 // Build the "dist" folder by running all of the named tasks
-gulp.task('build', ['pages', 'sass', 'javascript', 'images', 'copy', 'asis']);
+gulp.task('build', ['pages', 'sass', 'javascript', 'images', 'copy', 'asis', 'redirect']);
 
 // Clean the "dist" folder before recreating its contents
 gulp.task('rebuild', function(done) {

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var path = require('path');
+var through = require('through2');
+
+module.exports = function(opts) {
+    return through.obj(function(file, enc, cb) {
+        // var status = file.stem; // not supported by our version of gulp
+        var status = path.basename(file.relative, path.extname(file.relative));
+        if (['permanent', 'temp', 'seeother', 'gone'].indexOf(status) === -1)
+            throw Error('Unknown status: ' + status);
+        var data = JSON.parse(file.contents.toString());
+        var parts = [];
+        for (var src in data) {
+            var dst = data[src];
+            parts.push('Redirect ', status, ' "', src, '" "', dst, '"\n');
+        }
+        file.contents = new Buffer(parts.join(''));
+        cb(null, file);
+    });
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-util": "^3.0.7",
     "handlebars": "^4.0.5",
     "htmlparser2": "^3.9.0",
+    "marked": "^0.3.6",
     "merge-stream": "^1.0.0",
     "open": "0.0.5",
     "q": "^1.4.1",

--- a/src/redirect/permanent.json
+++ b/src/redirect/permanent.json
@@ -1,0 +1,4 @@
+{
+    "/gallery/cindygl/jugglers.html": "/gallery/cindygl/Jugglers/",
+    "/gallery/cindygl/raytracer.html": "/gallery/cindygl/Raytracer/"
+}


### PR DESCRIPTION
We already broke some links, and I'd like to see them restored. To clarify: I think our content is consistently linked to itself, but people may have bookmarked the old URL, or written about it in some external document, so what we broke are their bookmarks and external links.

I'm trying to think of ways to automatically check for such situations before they become live. But for now, let's just add redirects for the things I noticed.