### PR TITLE
Changed Euclid's Algorithm to use v0.8 Cindy.js

### DIFF
--- a/src/gallery/main/EuclidsAlgorithm/EuclidsAlg.html
+++ b/src/gallery/main/EuclidsAlgorithm/EuclidsAlg.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="http://cindyjs.org/dist/v0.8/Cindy.js"></script>
 
 
             </head>


### PR DESCRIPTION
Euclid's Algorithm suffers from the 49/49 != 1 bug, which is fixed in the v0.8 series