### PR TITLE
Replace http://cindyjs.org/.*(js|css) with /.*(js|css)

### DIFF
--- a/src/gallery/cindygl/Barnsley/Barnsley.html
+++ b/src/gallery/cindygl/Barnsley/Barnsley.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 <style type="text/css">
     * {
       border: 0;

--- a/src/gallery/cindygl/ComplexExplorer/ComplexExplorer.html
+++ b/src/gallery/cindygl/ComplexExplorer/ComplexExplorer.html
@@ -5,8 +5,8 @@
 <title>Cindy JS Example</title>
 <!--Adapted from http://science-to-touch.com/CJS/CindyJS/complexFunctions/04_Explorer.html -->
 <meta charset="UTF-8">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
 <script id="csinit" type="text/x-cindyscript">
 f(z, a, b, c, d, e, A, B, C, D) := (1-a)*(1+a);

--- a/src/gallery/cindygl/CoxeterTilings/CoxeterTilings.html
+++ b/src/gallery/cindygl/CoxeterTilings/CoxeterTilings.html
@@ -4,8 +4,8 @@
 		<meta charset="utf-8">
     <title>Cindy JS</title>
 
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/cindygl/Kleinian/Kleinian.html
+++ b/src/gallery/cindygl/Kleinian/Kleinian.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-         <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+         <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
            <link rel="stylesheet" href="../../css/cindy.css">
   </head>
 

--- a/src/gallery/cindygl/Raytracer/Raytracer.html
+++ b/src/gallery/cindygl/Raytracer/Raytracer.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/cindygl/ReactionDiffusion/ReactionDiffusion.html
+++ b/src/gallery/cindygl/ReactionDiffusion/ReactionDiffusion.html
@@ -4,8 +4,8 @@
 		<meta charset="utf-8">
     <title>Cindy JS</title>
 
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/main/AlternatingSeries/Alternating.html
+++ b/src/gallery/main/AlternatingSeries/Alternating.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 
 a(i):=1/i*(-1)^i;

--- a/src/gallery/main/Barnsley/Barnsley.html
+++ b/src/gallery/main/Barnsley/Barnsley.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 <style type="text/css">
     * {
       border: 0;

--- a/src/gallery/main/Bouncer/Bouncer.html
+++ b/src/gallery/main/Bouncer/Bouncer.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
             </head>

--- a/src/gallery/main/CircleReflections/SphereChaos.html
+++ b/src/gallery/main/CircleReflections/SphereChaos.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 C0.radius=max(2,C0.radius);
 C1.radius=max(2,C1.radius);

--- a/src/gallery/main/Clock/Clock.html
+++ b/src/gallery/main/Clock/Clock.html
@@ -4,7 +4,7 @@
 <head>
 <title>Cindy JS Example</title>
 <meta charset="UTF-8">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csinit" type="text/x-cindyscript">
 p(x):=[sin(2*pi*x),cos(2*pi*x)];
 clock():=(

--- a/src/gallery/main/ComplexExplorer/ComplexExplorer.html
+++ b/src/gallery/main/ComplexExplorer/ComplexExplorer.html
@@ -5,8 +5,8 @@
 <title>Cindy JS Example</title>
 <!--Adapted from http://science-to-touch.com/CJS/CindyJS/complexFunctions/04_Explorer.html -->
 <meta charset="UTF-8">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
 <script id="csinit" type="text/x-cindyscript">
 f(z, a, b, c, d, e, A, B, C, D) := (1-a)*(1+a);

--- a/src/gallery/main/ComplexGrid/ComplexGrid.html
+++ b/src/gallery/main/ComplexGrid/ComplexGrid.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
             </head>
 

--- a/src/gallery/main/ConicSections/ConicSections.html
+++ b/src/gallery/main/ConicSections/ConicSections.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
             </head>

--- a/src/gallery/main/ConicsAtInfinity/ConicsAtInfinity.html
+++ b/src/gallery/main/ConicsAtInfinity/ConicsAtInfinity.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 snap(X):=if(|X.xy-round(X.xy)|<0.2,X.xy=round(X.xy));
 apply([A,B,C,D,E],snap(#));

--- a/src/gallery/main/Continuity/Continuity.html
+++ b/src/gallery/main/Continuity/Continuity.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/latest/CindyJS.css">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/latest/CindyJS.css">
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 layer(4);
 clrscr();

--- a/src/gallery/main/CoxeterTilings/CoxeterTilings.html
+++ b/src/gallery/main/CoxeterTilings/CoxeterTilings.html
@@ -4,8 +4,8 @@
 		<meta charset="utf-8">
     <title>Cindy JS</title>
 
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/main/Divergence/Divergence.html
+++ b/src/gallery/main/Divergence/Divergence.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/latest/CindyJS.css">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/latest/CindyJS.css">
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 
 

--- a/src/gallery/main/ElectroStatic/ElectroStatic.html
+++ b/src/gallery/main/ElectroStatic/ElectroStatic.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/main/EuclidsAlgorithm/EuclidsAlg.html
+++ b/src/gallery/main/EuclidsAlgorithm/EuclidsAlg.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.8/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.8/Cindy.js"></script>
 
 
             </head>

--- a/src/gallery/main/FactorizationDiagrams/FactorizationDiagrams.html
+++ b/src/gallery/main/FactorizationDiagrams/FactorizationDiagrams.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
             <link rel="stylesheet" href="../css/cindy.css">
 
 

--- a/src/gallery/main/FordCircles/FordCircles.html
+++ b/src/gallery/main/FordCircles/FordCircles.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
             <link rel="stylesheet" href="../css/cindy.css">
 
 

--- a/src/gallery/main/Fourier/FourierSamples.html
+++ b/src/gallery/main/Fourier/FourierSamples.html
@@ -20,7 +20,7 @@
         }
     </style>
     <link rel="stylesheet" href="../../build/js/CindyJS.css">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 kmax=[50,50,50,50,50,50,50,50];
 col2=(0,0,1);

--- a/src/gallery/main/FourierSynth/FourierSynth.html
+++ b/src/gallery/main/FourierSynth/FourierSynth.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
-    <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/v0.7/CindyJS.css">
+    <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="cssimulationstart" type="text/x-cindyscript">
 tt=arctan2(B-A);
 </script>

--- a/src/gallery/main/HyperSlizer/HyperSlizer.html
+++ b/src/gallery/main/HyperSlizer/HyperSlizer.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
             <title>Cindy JS</title>
 
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
             </head>

--- a/src/gallery/main/IFS/IFS.html
+++ b/src/gallery/main/IFS/IFS.html
@@ -4,7 +4,7 @@
 <head>
 <title>Cindy JS Example</title>
 <meta charset="UTF-8">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csmousedrag" type="text/x-cindyscript">
 
 

--- a/src/gallery/main/ImageSpiral/ImageSpiral.html
+++ b/src/gallery/main/ImageSpiral/ImageSpiral.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
             </head>

--- a/src/gallery/main/JuliaConjugated/JuliaConjugated.html
+++ b/src/gallery/main/JuliaConjugated/JuliaConjugated.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/main/Kleinian/Kleinian.html
+++ b/src/gallery/main/Kleinian/Kleinian.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-         <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+         <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
            <link rel="stylesheet" href="../../css/cindy.css">
   </head>
 

--- a/src/gallery/main/Morley/Morley.html
+++ b/src/gallery/main/Morley/Morley.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csinit" type="text/x-cindyscript">
 traces=[0,0];
 rpoints = [AA, BB, CC];

--- a/src/gallery/main/Napoleon/Napoleon.html
+++ b/src/gallery/main/Napoleon/Napoleon.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/latest/CindyJS.css">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/latest/CindyJS.css">
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
     <script id="csdraw" type="text/x-cindyscript">
     fillpoly([A,B,C],color->(1,1,1)*.9);
     fillpoly([A,B,G],color->(1,.9,0));

--- a/src/gallery/main/NestedPolytopes/NestedPolytopes.html
+++ b/src/gallery/main/NestedPolytopes/NestedPolytopes.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
     <script id="csmouseup" type="text/x-cindyscript">

--- a/src/gallery/main/NewtonFractal/Newton.html
+++ b/src/gallery/main/NewtonFractal/Newton.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>
     

--- a/src/gallery/main/NonDiff/NonDiff.html
+++ b/src/gallery/main/NonDiff/NonDiff.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
-    <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/v0.7/CindyJS.css">
+    <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 nn=round(|A,C|/|A,B|*6);
 

--- a/src/gallery/main/Optics/Optics.html
+++ b/src/gallery/main/Optics/Optics.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 
 virtualbeams=true;

--- a/src/gallery/main/PolygonalSpiral/PolygonalSpiral.html
+++ b/src/gallery/main/PolygonalSpiral/PolygonalSpiral.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
 

--- a/src/gallery/main/ProjectiveParallels/ProjGrid3.html
+++ b/src/gallery/main/ProjectiveParallels/ProjGrid3.html
@@ -20,7 +20,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
     
     
 <script id="csinit" type="text/x-cindyscript">

--- a/src/gallery/main/Ptolemy/Ptolemy.html
+++ b/src/gallery/main/Ptolemy/Ptolemy.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 drawtext(A+(A-F)/|A-F|*1.4-(.2,.2),"A",size->20);
 drawtext(B+(B-F)/|B-F|*1.4-(.2,.2),"B",size->20);

--- a/src/gallery/main/PythN-Eck/ZerlegungsgleichN-Eck.html
+++ b/src/gallery/main/PythN-Eck/ZerlegungsgleichN-Eck.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 l=|O,M|/|M,N|;
 

--- a/src/gallery/main/RandomTree/RandomTree.html
+++ b/src/gallery/main/RandomTree/RandomTree.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
     <style type="text/css">
         * {
           border: 0;

--- a/src/gallery/main/Raytracer/Raytracer.html
+++ b/src/gallery/main/Raytracer/Raytracer.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/main/ReactionDiffusion/ReactionDiffusion.html
+++ b/src/gallery/main/ReactionDiffusion/ReactionDiffusion.html
@@ -4,8 +4,8 @@
 		<meta charset="utf-8">
     <title>Cindy JS</title>
 
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/gallery/main/Regression/Regression.html
+++ b/src/gallery/main/Regression/Regression.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 
 
 

--- a/src/gallery/main/SpaceFilling/Peano.html
+++ b/src/gallery/main/SpaceFilling/Peano.html
@@ -19,7 +19,7 @@
             width: 100%;
         }
     </style>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 layer(3);
 clrscr();

--- a/src/gallery/main/Spiro/Spiro.html
+++ b/src/gallery/main/Spiro/Spiro.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/v0.7/CindyJS.css">
-    <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/v0.7/CindyJS.css">
+    <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csdraw" type="text/x-cindyscript">
 n=round(|D,F|*8-8);
 m=round(|O,M|*8-8);

--- a/src/gallery/main/Stereographic/Stereographic.html
+++ b/src/gallery/main/Stereographic/Stereographic.html
@@ -19,8 +19,8 @@
             width: 100%;
         }
     </style>
-    <link rel="stylesheet" href="http://cindyjs.org/dist/latest/CindyJS.css">
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+    <link rel="stylesheet" href="/dist/latest/CindyJS.css">
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
 <script id="csmouseup" type="text/x-cindyscript">
 //apply(allpoints(),#.selected=false);
 rotating=true;

--- a/src/gallery/main/Sunflower/Sunflower.html
+++ b/src/gallery/main/Sunflower/Sunflower.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
         <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
     </head>
 
 	<body style="font-family:Arial;">

--- a/src/gallery/main/Swarm/Swarm.html
+++ b/src/gallery/main/Swarm/Swarm.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
             <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.8/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.8/Cindy.js"></script>
 
 
             </head>

--- a/src/gallery/main/WaveIntersection/WaveIntersection.html
+++ b/src/gallery/main/WaveIntersection/WaveIntersection.html
@@ -3,8 +3,8 @@
 	<head>
 		<meta charset="utf-8">
     <title>Cindy JS</title>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
-        <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/CindyGL.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
+        <script type="text/javascript" src="/dist/v0.7/CindyGL.js"></script>
 
     <link rel="stylesheet" href="../../css/cindy.css">
   </head>

--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -32,7 +32,7 @@ There are three relevant parts to most CindyJS widgets:
 1. Reference the `Cindy.js` script in your HTML file,
    by adding the following line to the header of your file:
    ```html
-   <script type="text/javascript" src="http://cindyjs.org/dist/v0.7/Cindy.js"></script>
+   <script type="text/javascript" src="/dist/v0.7/Cindy.js"></script>
    ```
    This adds a function called `CindyJS` to the global scope.
 2. Invoke that function, providing an object with further content description.

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -306,4 +306,3 @@ colorplot(
   color(f(z))
 );
 </script>
-


### PR DESCRIPTION
We need this since cindyjs.org is now available through both http://cindyjs.org/ and https://cindyjs.org/. If the later page is accessed some Mixed Content errors were thrown: A page that was loaded over HTTPS cannot request an insecure script from http://cindyjs.org/