### PR TITLE
Fix thumbnail script

### DIFF
--- a/generatethumbnails
+++ b/generatethumbnails
@@ -4,10 +4,8 @@ cd CindyJS
 make
 cd ../src/assets/img/thumbnail
 
-phantomjs cindyscreenshot.js ../../../../CindyJS/examples/**.html
-
-for i in `ls *png`
+phantomjs cindyscreenshot.js ../../../../CindyJS/examples/
+for i in `find ../../../../CindyJS/examples/ -type d`
 do
-  echo "convert" $i
-  convert $i -filter Lanczos -resize 300x300^ -gravity center -extent 300x300 $i
+  phantomjs cindyscreenshot.js $i/*.html
 done

--- a/src/assets/img/thumbnail/cindyscreenshot.js
+++ b/src/assets/img/thumbnail/cindyscreenshot.js
@@ -2,6 +2,7 @@
 
 var system = require('system');
 var fs = require('fs');
+var exec = require('child_process').exec;
 
 if (system.args.length < 2) {
     console.log('Usage: phantomjs gallery.js FILE[s]');
@@ -71,6 +72,9 @@ function renderimage(address, output) {
                 
                 console.log("rendering " + output);
                 page.render(output);
+                
+                console.log("converting " + output);
+                exec("convert " + output + " -filter Lanczos -resize 300x300^ -gravity center -extent 300x300 " + output)
                 
                 emptyqueue();
             }, 1000);


### PR DESCRIPTION
Now `generatethumbnails` will also generate thumbnails for the plugins. Furthermore `convert` (imagemagick) is only called if the thumbnail has been recently generated.