### PR TITLE
Use basename when creating alphabetical function index

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -14,7 +14,6 @@ module.exports = function() {
     var strm = new stream.Transform({
         objectMode: true,
         transform: function(file, enc, cb) {
-            console.log("Seeing " + file.relative);
             someFile = file;
             var md = file.contents.toString();
             var title = reTitle.exec(md);
@@ -24,7 +23,7 @@ module.exports = function() {
                 title = title[0].substr(1).trim();
             }
             file.path = file.path.replace(/\.[^.]+$/, ".html");
-            pipeline.addPage(file.relative, md, {
+            pipeline.addPage(path.basename(file.path), md, {
                 title: title,
                 file: file
             });
@@ -52,9 +51,6 @@ module.exports = function() {
                 file.data.title = extra.title;
         } else {
             // A file created in the process, e.g. alphabetical index
-            console.log(someFile);
-            console.log(path.dirname(someFile.path));
-            console.log(page.name);
             file = new vinyl({
                 contents: contents,
                 cwd: someFile.cwd,


### PR DESCRIPTION
Fixes #57.