### PR TITLE
Fix typo and build system

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-markdown": "^1.2.0",
     "gulp-minify-css": "^1.2.1",
     "gulp-newer": "^1.1.0",
-    "gulp-sass": "^2.1.0",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglify": "^1.2.0",
     "gulp-uncss": "^1.0.1",

--- a/src/gallery/main/NonDiff/index.json
+++ b/src/gallery/main/NonDiff/index.json
@@ -1,6 +1,6 @@
 {
   "widget": "NonDiff.html",
   "thumbnail": "NonDiff.png",
-  "title-en": "contineous but not differentiable",
+  "title-en": "continuous but not differentiable",
   "en": "description.md"
 }


### PR DESCRIPTION
Fixes a typo in NonDiff example.

Also updates `gulp-sass` to `^3.1.0` and submodule `CindyJS` to `89a9d2f8de86786f29b14fa5b7520b9d837214ac` in order to fix build issues relating to compilation of an old version of `sass`.