### PR TITLE
add links to /docs/cindygltutorial/

### DIFF
--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -49,7 +49,9 @@ There are three relevant parts to most CindyJS widgets:
 
 ### Tutorials
 
-At this point there are no official tutorials for CindyJS.
+There is a [CindyGL-Tutorial](/docs/cindygltutorial/), that is also suitable for starting with CindyJS.
+
+At this point there are no further official tutorials for CindyJS.
 If you want to write one, please contact the development team.
 If you follow the route of exporting content from Cinderella, one of
 [Cinderella's tutorials](http://doc.cinderella.de/tiki-index.php?page=Introduction+to+the+Tutorials)

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -58,6 +58,7 @@ but also from various other fields.
       <option value="repeat(11, z = z - (z^3-1)/(3*z^2));">Newton</option>
     </select></p>
   <p>For more WebGL-related content, visit our <a href="/gallery/cindygl/">CindyGL-Gallery</a>.</p>
+  <p>If you want to learn how to program your CindyGL applications you can check out <a href="/docs/cindygltutorial/">our CindyGL-tutorial</a>.</p>
 </div></div>
 
 


### PR DESCRIPTION
With this, the CindyGL-tutorial becomes public